### PR TITLE
adding warning about the long run time of the model select app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ After fitting a continuous-time movement model, this app allows to reconstruct t
 
 For details and background of the method please see the [publication](https://esajournals.onlinelibrary.wiley.com/doi/full/10.1890/15-1607.1) and the methods description in the [documentation of the occurance function](https://ctmm-initiative.github.io/ctmm/reference/occurrence.html) of the ctmm package. The occurrence distribution attempts to calculate the track of the animal, while the range distribution (i.e., the result of the aKDE app) calculates the long-term space use.
 
+**ATTENTION**: The preceding App *`Fit a Continuous-Time Movement Model (ctmm)`* can have a long run time (hours). Consider pinning this app for further workflow runs. Subsequent apps like *`Autocorrelated Kernel Density Estimate (aKDE)`* and *`Estimate Occurrence Distribution (Kriging)`* with interactive user interface (once the app has run a button "OPEN APP UI" appears) can only be accessed for 8 hours (afterwards the "OPEN APP UI" is not visible anymore). To get again access to it, the workflow has to be run again. BUT before doing this, pin the workflow to the *`Fit a Continuous-Time Movement Model (ctmm)`* (menu at the top right corner of the App - *"Pin to this App"*) to avoid the long run time again. An app can only be pinned once it has run and produced results.
+
 ### Input data
 The app requires a `ctmm model with data` as input. 
 


### PR DESCRIPTION
Hi @jmsigner und @marcosci, um zu vermeiden das die User verzweifeln weil sie immer den moment verpassen um das UI auf zu machen habe ich bei allen 3 apps (model select, akde, ocurrence) eine art von Warning message hinzugefügt. Ich habe auch einen ähnlichen text in euren Public Workflow hinzugefügt.

In dieser App ist mir noch zusätzlich was aufgefallen, nichts wirklich wichtiges: 
- die Karte in akde app könnte eventuell etwas größer sein, und hier etwas kleiner. Hier ist die Karte so groß das man sie nicht ganz auf den Bildschirm bekommt, sondern immer hoch/runter scrollen muss 
- hier gibt es den button "full extent" nicht, falls es so mit Absicht ist, ist ok.